### PR TITLE
fix(package.json): lint 명령어 버그 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "start:dev": "rimraf dist && cross-env NODE_ENV=development nest build --webpack --webpackPath webpack-hmr.config.js --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
-    "lint": "eslint **/*.{ts,tsx}",
+    "lint": "eslint \"{src,apps,libs,test}/**/*.ts\"",
     "lint:fix": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
dist 폴더가 있을시 커밋이 안되는 버그
lint 명령어로 dist 폴더를 검사하지 않게 변경