### PR TITLE
Feat/jwt token

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -65,12 +65,10 @@ export class AuthService {
       user_token: 'onceToken',
     };
 
-    return {
-      access_token: this.jwtService.sign(payload, {
-        secret: process.env.JWT_SECRET,
-        expiresIn: '10m',
-      }),
-    };
+    return this.jwtService.sign(payload, {
+      secret: process.env.JWT_SECRET,
+      expiresIn: '10m',
+    });
   }
 
   async tokenValidate(token: string) {

--- a/src/auth/guard/jwt-auth.guard.ts
+++ b/src/auth/guard/jwt-auth.guard.ts
@@ -55,12 +55,21 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
       if (token_verify.user_token === 'loginToken') {
         if (time_remaining < 5) {
           // 로그인 토큰의남은 시간이 5분 미만일때
-          const user = await this.userService.findUserById(
+          // 엑세스 토큰 정보로 유저를 찾는다.
+          const access_token_user = await this.userService.findUserById(
             token_verify.user_no,
           );
-          const new_token = await this.authService.createLoginToken(user);
+          const refresh_token = await this.authService.tokenValidate(
+            access_token_user.user_refresh_token,
+          );
+          const refresh_token_user = await this.userService.findUserById(
+            refresh_token.user_no,
+          );
+          const new_token = await this.authService.createLoginToken(
+            refresh_token_user,
+          );
           return {
-            user,
+            user: refresh_token_user,
             new_token,
             tokenReissue: true,
           };

--- a/src/auth/strategy/kakao.strategy.ts
+++ b/src/auth/strategy/kakao.strategy.ts
@@ -29,13 +29,14 @@ export class KakaoStrategy extends PassportStrategy(Strategy, 'kakao') {
     if (user === null) {
       // 유저가 없을때
       console.log('일회용 토큰 발급');
-      return this.authService.onceToken(user_profile);
+      const once_token = this.authService.onceToken(user_profile);
+      return { once_token, type: 'once' };
     }
 
     // 유저가 있을때
     console.log('로그인 토큰 발급');
     const access_token = await this.authService.createLoginToken(user);
     const refresh_token = await this.authService.createRefreshToken(user);
-    return { access_token, refresh_token };
+    return { access_token, refresh_token, type: 'login' };
   }
 }

--- a/src/auth/strategy/naver.strategy.ts
+++ b/src/auth/strategy/naver.strategy.ts
@@ -32,13 +32,14 @@ export class NaverStrategy extends PassportStrategy(Strategy) {
     if (user === null) {
       // 유저가 없을때
       console.log('일회용 토큰 발급');
-      return this.authService.onceToken(user_profile);
+      const once_token = this.authService.onceToken(user_profile);
+      return { once_token, type: 'once' };
     }
 
     // 유저가 있을때
     console.log('로그인 토큰 발급');
     const access_token = await this.authService.createLoginToken(user);
     const refresh_token = await this.authService.createRefreshToken(user);
-    return { access_token, refresh_token };
+    return { access_token, refresh_token, type: 'login' };
   }
 }


### PR DESCRIPTION
1. 엑세스 토큰 재발급과정 수정
기존 엑세스토큰을 이용한 API요청시 토큰의 남은시간 체크 후 재발급 하는 과정을
엑세스 토큰의 유저정보에서 리프레쉬 토큰을 찾아 리프레쉬 토큰의 정보를 기반으로 엑세스 토큰을 재발급함
2. 최초 로그인시, 정보가 있는 유저 별 쿠키에 담는 토큰 이름 값 변경
3. 최초 로그인시 엑세스 토큰과 리프레쉬 토큰 헤더에 전송

소셜 로그인시 토큰만 쿠키로 전송
서버와 통신할때 재발급 또는 생성하는 토큰은 기존과 동일하게 헤더로 전송